### PR TITLE
Add resetEnv to every test, share delivery object

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,41 @@
+# Testing the Go BugSnag performance SDK
+
+## Unit tests
+
+```
+go test ./...
+```
+
+## End-to-end tests
+
+These tests are implemented with our internal testing tool [Maze Runner](https://github.com/bugsnag/maze-runner).
+
+End to end tests are written in cucumber-style `.feature` files, and need Ruby-backed "steps" in order to know what to run. The tests are located in the top level [`features`](./features/) directory.
+
+The Maze Runner test fixtures are containerised so you'll need Docker and Docker Compose to run them.
+
+### Running the end to end tests
+
+Install Maze Runner:
+
+```sh
+$ bundle install
+```
+
+Configure the tests to be run in the following way:
+
+- Determine the Go version to be tested using the environment variable `GO_VERSION`, e.g. `GO_VERSION=1.19`
+- Determine the Open Telemetry SDK version using the environment variable `OTEL_VERSION`, e.g. `OTEL_VERSION=1.20`
+
+Here is a list of compatible Go x OTeL versions (OTeL version 1.22 is skipped as it has some incompatibilities with semconv package):
+* For Go 1.19 - OTeL 1.17 - 1.24
+* For Go 1.20 - OTeL 1.17 - 1.24
+* For Go 1.21 - OTeL 1.17 - 1.29
+* For Go 1.22 - OTeL 1.17 - 1.29
+* For Go 1.23 - OTeL 1.17 - 1.29
+
+Use the Maze Runner CLI to run the tests:
+
+```sh
+$ GO_VERSION=1.19 OTEL_VERSION=1.20 bundle exec maze-runner
+```

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -34,10 +34,11 @@ func Configure(config Configuration) (trace.Sampler, []trace.SpanProcessor, erro
 		return nil, nil, err
 	}
 
+	delivery := createDelivery()
 	// TODO get context from user
-	probabilityManager := createProbabilityManager(context.Background(), REFRESH_INTERVAL, RETRY_INTERVAL)
+	probabilityManager := createProbabilityManager(context.Background(), delivery)
 	sampler := createSampler(probabilityManager)
-	spanExporter := createSpanExporter(probabilityManager, sampler)
+	spanExporter := createSpanExporter(probabilityManager, sampler, delivery)
 	probAttrProcessor := createProbabilityAttributeProcessor(probabilityManager)
 	// Batch processor with default settings
 	bsgSpanProcessor := trace.NewBatchSpanProcessor(spanExporter)

--- a/bugsnag_performance_test.go
+++ b/bugsnag_performance_test.go
@@ -1,0 +1,12 @@
+package bugsnagperformance
+
+import (
+	"os"
+)
+
+func resetEnv() {
+	os.Clearenv()
+	Config = Configuration{
+		ReleaseStage: "production",
+	}
+}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -7,17 +7,9 @@ import (
 	"testing"
 )
 
-func resetEnv() {
-	os.Clearenv()
-	Config = Configuration{
-		ReleaseStage: "production",
-	}
-}
-
 // Needs to be first to test sync.Once for loadEnv
 func TestConfigureTwiceEnv(t *testing.T) {
 	resetEnv()
-
 	testConfig := Configuration{
 		APIKey:               "aaa",
 		Endpoint:             "https://aaa.otlp.bugsnag.com/v1/traces",
@@ -53,7 +45,6 @@ func TestConfigureTwiceEnv(t *testing.T) {
 
 func TestConfigureEmpty(t *testing.T) {
 	resetEnv()
-
 	_, _, err := Configure(Configuration{})
 	if err == nil {
 		t.Error("should return error on empty api key")
@@ -62,7 +53,6 @@ func TestConfigureEmpty(t *testing.T) {
 
 func TestDefaultValues(t *testing.T) {
 	resetEnv()
-
 	testConfig := Configuration{
 		APIKey:               "aaa",
 		Endpoint:             "https://aaa.otlp.bugsnag.com/v1/traces",
@@ -83,7 +73,6 @@ func TestDefaultValues(t *testing.T) {
 
 func TestConfigureOverwriteDefault(t *testing.T) {
 	resetEnv()
-
 	testConfig := Configuration{
 		APIKey:               "bbb",
 		Endpoint:             "myendpoint",
@@ -103,7 +92,6 @@ func TestConfigureOverwriteDefault(t *testing.T) {
 
 func TestConfigureMixedSetup(t *testing.T) {
 	resetEnv()
-
 	testConfig := Configuration{
 		APIKey:               "bbb",
 		Endpoint:             "https://bbb.otlp.bugsnag.com/v1/traces",
@@ -130,7 +118,6 @@ func TestConfigureMixedSetup(t *testing.T) {
 
 func TestConfigureTwice(t *testing.T) {
 	resetEnv()
-
 	testConfig := Configuration{
 		APIKey:               "aaa",
 		Endpoint:             "https://aaa.otlp.bugsnag.com/v1/traces",
@@ -166,7 +153,6 @@ func TestConfigureTwice(t *testing.T) {
 
 func TestConfigureNotifierEnv(t *testing.T) {
 	resetEnv()
-
 	testConfig := Configuration{
 		APIKey:               "aaa",
 		Endpoint:             "https://aaa.otlp.bugsnag.com/v1/traces",

--- a/consts.go
+++ b/consts.go
@@ -1,7 +1,12 @@
 package bugsnagperformance
 
+import "time"
+
 const (
 	samplingAttribute      = "bugsnag.sampling.p"
 	samplingResponseHeader = "Bugsnag-Sampling-Probability"
 	samplingRequestHeader  = "Bugsnag-Span-Sampling"
+	fetcherRetryInterval   = 30 * time.Second
+	fetcherRefreshInterval = 24 * time.Hour
+	fetcherRequestBody     = `{"resourceSpans": []}`
 )

--- a/delivery.go
+++ b/delivery.go
@@ -68,15 +68,15 @@ func (d *delivery) sendPayload(payload []byte) (*http.Response, error) {
 	return resp, nil
 }
 
-func createDelivery(uri, apiKey string) *delivery {
+func createDelivery() *delivery {
 	headers := map[string]string{
-		"Bugsnag-Api-Key": apiKey,
+		"Bugsnag-Api-Key": Config.APIKey,
 		"Content-Type":    "application/json",
 		"User-Agent":      fmt.Sprintf("Go Bugsnag Performance SDK v%v", Version),
 	}
 
 	return &delivery{
-		uri:     uri,
+		uri:     Config.Endpoint,
 		headers: headers,
 	}
 }

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestParsedEmptyResponse(t *testing.T) {
+	resetEnv()
 	rawResponse := http.Response{}
 	response := newParsedResponse(rawResponse)
 
@@ -21,6 +22,7 @@ func TestParsedEmptyResponse(t *testing.T) {
 }
 
 func TestParsedIncorrectHeader(t *testing.T) {
+	resetEnv()
 	header := map[string][]string{
 		samplingResponseHeader: {"invalid"},
 	}
@@ -37,6 +39,7 @@ func TestParsedIncorrectHeader(t *testing.T) {
 }
 
 func TestParsedIncorrectProbability(t *testing.T) {
+	resetEnv()
 	header := map[string][]string{
 		samplingResponseHeader: {"2.0"},
 	}
@@ -53,6 +56,7 @@ func TestParsedIncorrectProbability(t *testing.T) {
 }
 
 func TestParsedCorrectProbability(t *testing.T) {
+	resetEnv()
 	header := map[string][]string{
 		samplingResponseHeader: {"0.5"},
 	}
@@ -69,6 +73,7 @@ func TestParsedCorrectProbability(t *testing.T) {
 }
 
 func TestHeadersPresentAtSend(t *testing.T) {
+	resetEnv()
 	testAPIKey := "12356789"
 
 	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -90,7 +95,9 @@ func TestHeadersPresentAtSend(t *testing.T) {
 	}))
 	defer testSrv.Close()
 
-	delivery := createDelivery(testSrv.URL, testAPIKey)
+	Config.Endpoint = testSrv.URL
+	Config.APIKey = testAPIKey
+	delivery := createDelivery()
 	_, err := delivery.send(map[string]string{"key1": "value1"}, []byte("test"))
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)

--- a/payload_encoder_test.go
+++ b/payload_encoder_test.go
@@ -84,6 +84,7 @@ func prepareEvents() []sdktrace.Event {
 }
 
 func TestAttributesToJSON(t *testing.T) {
+	resetEnv()
 	pe := &payloadEncoder{}
 	attributes := []attribute.KeyValue{
 		{
@@ -119,6 +120,7 @@ func TestAttributesToJSON(t *testing.T) {
 }
 
 func TestLinksListEncoding(t *testing.T) {
+	resetEnv()
 	pe := &payloadEncoder{}
 	output := pe.linksToSlice(prepareLinks())
 
@@ -128,6 +130,7 @@ func TestLinksListEncoding(t *testing.T) {
 }
 
 func TestEventListEncoding(t *testing.T) {
+	resetEnv()
 	pe := &payloadEncoder{}
 	output := pe.eventsToSlice(prepareEvents())
 

--- a/probability_attribute_processor_test.go
+++ b/probability_attribute_processor_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestDoesNotReplaceExistingAttribute(t *testing.T) {
+	resetEnv()
 	probMgr := &probabilityManager{}
 	probMgr.probability = 0.25
 	testProc := createProbabilityAttributeProcessor(probMgr)
@@ -37,6 +38,7 @@ func TestDoesNotReplaceExistingAttribute(t *testing.T) {
 }
 
 func TestAddsProbabilityAttribute(t *testing.T) {
+	resetEnv()
 	probMgr := &probabilityManager{}
 	probMgr.probability = 0.25
 	testProc := createProbabilityAttributeProcessor(probMgr)

--- a/probability_fetcher_test.go
+++ b/probability_fetcher_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestFetchCorrectProbability(t *testing.T) {
 	resetEnv()
-
 	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(samplingResponseHeader, "0.1234")
 	}))
@@ -26,13 +25,12 @@ func TestFetchCorrectProbability(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pf := CreateProbabilityFetcher(ctx, 50*time.Second, 300*time.Millisecond, testCallback)
+	pf := createProbabilityFetcherInternal(ctx, 50*time.Second, 300*time.Millisecond, createDelivery(), testCallback)
 	pf.fetchProbability()
 }
 
 func TestRetriesForError(t *testing.T) {
 	resetEnv()
-
 	count := 0
 	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if count == 5 {
@@ -55,13 +53,12 @@ func TestRetriesForError(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pf := CreateProbabilityFetcher(ctx, 50*time.Second, 300*time.Millisecond, testCallback)
+	pf := createProbabilityFetcherInternal(ctx, 50*time.Second, 300*time.Millisecond, createDelivery(), testCallback)
 	pf.fetchProbability()
 }
 
 func TestRetriesOnIncorrectValue(t *testing.T) {
 	resetEnv()
-
 	count := 0
 	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch count {
@@ -90,13 +87,12 @@ func TestRetriesOnIncorrectValue(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pf := CreateProbabilityFetcher(ctx, 50*time.Second, 300*time.Millisecond, testCallback)
+	pf := createProbabilityFetcherInternal(ctx, 50*time.Second, 300*time.Millisecond, createDelivery(), testCallback)
 	pf.fetchProbability()
 }
 
 func TestUpdateValueAfterRefresh(t *testing.T) {
 	resetEnv()
-
 	count := 0
 	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch count {
@@ -123,7 +119,7 @@ func TestUpdateValueAfterRefresh(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pf := CreateProbabilityFetcher(ctx, 2*time.Second, 300*time.Millisecond, testCallback)
+	pf := createProbabilityFetcherInternal(ctx, 2*time.Second, 300*time.Millisecond, createDelivery(), testCallback)
 	pf.fetchProbability()
 	// second fetch should be after 2 seconds
 	time.Sleep(3 * time.Second)

--- a/probability_manager.go
+++ b/probability_manager.go
@@ -3,7 +3,6 @@ package bugsnagperformance
 import (
 	"context"
 	"sync"
-	"time"
 )
 
 type probabilityManager struct {
@@ -12,13 +11,13 @@ type probabilityManager struct {
 	mtx                sync.Mutex
 }
 
-func createProbabilityManager(ctx context.Context, refreshInterval, retryInterval time.Duration) *probabilityManager {
+func createProbabilityManager(ctx context.Context, delivery *delivery) *probabilityManager {
 	probMgr := &probabilityManager{
 		probability: 1.0,
 	}
 
 	// Will fetch value from the server and update the probability on start
-	probFetch := CreateProbabilityFetcher(ctx, refreshInterval, retryInterval, probMgr.setProbability)
+	probFetch := createProbabilityFetcher(ctx, delivery, probMgr.setProbability)
 	probMgr.probabilityFetcher = probFetch
 	go probFetch.fetchProbability()
 

--- a/probability_manager_test.go
+++ b/probability_manager_test.go
@@ -10,7 +10,6 @@ import (
 
 func TestProbabilityManagerSetProbability(t *testing.T) {
 	resetEnv()
-
 	testSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(samplingResponseHeader, "0.1234")
 	}))
@@ -19,9 +18,21 @@ func TestProbabilityManagerSetProbability(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	pMgr := createProbabilityManager(ctx, 50*time.Second, 300*time.Millisecond)
+	pMgr := createProbabilityManager(ctx, createDelivery())
+
+	// default probability is 1.0
+	if pMgr.getProbability() != 1.0 {
+		t.Errorf("Expected probability to be 1.0, got %f", pMgr.getProbability())
+	}
+
+	// wait for the first fetch to complete
+	time.Sleep(1 * time.Second)
+	if pMgr.getProbability() != 0.1234 {
+		t.Errorf("Expected probability to be 0.1234, got %f", pMgr.getProbability())
+	}
 
 	time.Sleep(2 * time.Second)
+	// manual setup
 	pMgr.setProbability(0.5)
 	if pMgr.getProbability() != 0.5 {
 		t.Errorf("Expected probability to be 0.5, got %f", pMgr.getProbability())

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestShouldSampleOnProbability1(t *testing.T) {
+	resetEnv()
 	tracestate, _ := trace.ParseTraceState("")
 	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	sampler := createSampler(nil)
@@ -22,6 +23,7 @@ func TestShouldSampleOnProbability1(t *testing.T) {
 }
 
 func TestShouldNotSampleOnProbability0(t *testing.T) {
+	resetEnv()
 	tracestate, _ := trace.ParseTraceState("")
 	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
 	sampler := createSampler(nil)
@@ -32,6 +34,7 @@ func TestShouldNotSampleOnProbability0(t *testing.T) {
 }
 
 func TestSampleWithSpecificTraceID(t *testing.T) {
+	resetEnv()
 	tracestate, _ := trace.ParseTraceState("")
 	traceID, _ := trace.TraceIDFromHex("2b0eb6c82ae431ad7fdc00306faebef6")
 	sampler := createSampler(nil)
@@ -42,6 +45,7 @@ func TestSampleWithSpecificTraceID(t *testing.T) {
 }
 
 func TestNotSampleWithSpecificTraceID(t *testing.T) {
+	resetEnv()
 	tracestate, _ := trace.ParseTraceState("")
 	traceID, _ := trace.TraceIDFromHex("98e03bf7fc2715bdcf426f549ca74150")
 	sampler := createSampler(nil)
@@ -52,6 +56,7 @@ func TestNotSampleWithSpecificTraceID(t *testing.T) {
 }
 
 func TestShouldSampleHalfOfSpans(t *testing.T) {
+	resetEnv()
 	probMgr := &probabilityManager{}
 	probMgr.probability = 0.5
 
@@ -89,6 +94,7 @@ func TestShouldSampleHalfOfSpans(t *testing.T) {
 }
 
 func TestResample(t *testing.T) {
+	resetEnv()
 	probMgr := &probabilityManager{}
 	probMgr.probability = 0.5
 	sampler := createSampler(probMgr)
@@ -138,6 +144,7 @@ var samplerTests = []samplerTestData{
 }
 
 func TestSampleUsingTracestate(t *testing.T) {
+	resetEnv()
 	for _, item := range samplerTests {
 		probMgr := &probabilityManager{}
 		probMgr.probability = item.probability

--- a/sampling_header_encoder_test.go
+++ b/sampling_header_encoder_test.go
@@ -29,6 +29,7 @@ func getSpans(exporter *tracetest.InMemoryExporter) []managedSpan {
 }
 
 func TestDefaultHeaderValue(t *testing.T) {
+	resetEnv()
 	enc := &samplingHeaderEncoder{}
 
 	result := enc.encode([]managedSpan{})
@@ -38,6 +39,7 @@ func TestDefaultHeaderValue(t *testing.T) {
 }
 
 func TestMissingAttribute(t *testing.T) {
+	resetEnv()
 	enc := &samplingHeaderEncoder{}
 	testExporter := tracetest.NewInMemoryExporter()
 	tracerProvider := trace.NewTracerProvider(trace.WithSpanProcessor(trace.NewSimpleSpanProcessor(testExporter)))
@@ -68,6 +70,7 @@ var attrTests = []samplingHeaderTestData{
 }
 
 func TestAttributes(t *testing.T) {
+	resetEnv()
 	//prepare huge array of probabilities
 	probabilities := make([]float64, 300)
 	for i := 0; i < 100; i++ {
@@ -102,6 +105,7 @@ func TestAttributes(t *testing.T) {
 }
 
 func TestResampled(t *testing.T) {
+	resetEnv()
 	enc := &samplingHeaderEncoder{}
 	testExporter := tracetest.NewInMemoryExporter()
 	tracerProvider := trace.NewTracerProvider(trace.WithSpanProcessor(trace.NewSimpleSpanProcessor(testExporter)))

--- a/span_exporter.go
+++ b/span_exporter.go
@@ -24,9 +24,7 @@ type managedSpan struct {
 	span                trace.ReadOnlySpan
 }
 
-func createSpanExporter(probMgr *probabilityManager, sampler *Sampler) trace.SpanExporter {
-	delivery := createDelivery(Config.Endpoint, Config.APIKey)
-
+func createSpanExporter(probMgr *probabilityManager, sampler *Sampler, delivery *delivery) trace.SpanExporter {
 	sp := SpanExporter{
 		disabled:                    false,
 		loggedFirstBatchDestination: false,

--- a/tracestate_parser_test.go
+++ b/tracestate_parser_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestEmptyTracestate(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("")
 	parsedState := parser.parse(state)
@@ -26,6 +27,7 @@ func TestEmptyTracestate(t *testing.T) {
 }
 
 func TestTracestateNoSmartbearValues(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("ab=c:1,xyz=lmn:op")
 	parsedState := parser.parse(state)
@@ -45,6 +47,7 @@ func TestTracestateNoSmartbearValues(t *testing.T) {
 }
 
 func TestTracestateNoVersion64(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("ab=c:1,xyz=lmn:op,sb=r64:1234")
 	parsedState := parser.parse(state)
@@ -64,6 +67,7 @@ func TestTracestateNoVersion64(t *testing.T) {
 }
 
 func TestTracestateNoVersion32(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("ab=c:1,xyz=lmn:op,sb=r32:1234")
 	parsedState := parser.parse(state)
@@ -83,6 +87,7 @@ func TestTracestateNoVersion32(t *testing.T) {
 }
 
 func TestTracestateNoRValue(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("ab=c:1,xyz=lmn:op,sb=v:1")
 	parsedState := parser.parse(state)
@@ -102,6 +107,7 @@ func TestTracestateNoRValue(t *testing.T) {
 }
 
 func TestTracestateFull64(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("ab=c:1,xyz=lmn:op,sb=v:2;r64:999")
 	parsedState := parser.parse(state)
@@ -127,6 +133,7 @@ func TestTracestateFull64(t *testing.T) {
 }
 
 func TestTracestateFull32(t *testing.T) {
+	resetEnv()
 	parser := &tracestateParser{}
 	state, _ := trace.ParseTraceState("ab=c:1,xyz=lmn:op,sb=v:2;r32:999")
 	parsedState := parser.parse(state)


### PR DESCRIPTION
Add Testing.md file with instructions on maze runner tests.
Share delivery object.
Add `resetEnv` before every unit test (because those are whitebox tests and we have a global config variable).
Remove duplicated check for parsed probability.
Separate probability fetcher create function to internal version to be able to set intervals for testing.