### PR TITLE
Add SDK name and version to bugsnag attributes

### DIFF
--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -83,19 +83,19 @@ func createBugsnagMergedResource() *resource.Resource {
 
 	attr := []attribute.KeyValue{
 		{
-			Key:   "deployment.environment",
+			Key:   deploymentEnvAttribute,
 			Value: attribute.StringValue(Config.ReleaseStage),
 		},
 		{
-			Key:   "service.version",
+			Key:   serviceVersionAttribute,
 			Value: attribute.StringValue(Config.AppVersion),
 		},
 		{
-			Key:   "bugsnag.telemetry.sdk.name",
-			Value: attribute.StringValue("Go Bugsnag Performance SDK"),
+			Key:   bugsnagTelemetrySDKName,
+			Value: attribute.StringValue(sdkName),
 		},
 		{
-			Key:   "bugsnag.telemetry.sdk.version",
+			Key:   bugsnagTelemetrySDKVer,
 			Value: attribute.StringValue(Version),
 		},
 	}

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -91,11 +91,11 @@ func createBugsnagMergedResource() *resource.Resource {
 			Value: attribute.StringValue(Config.AppVersion),
 		},
 		{
-			Key:   bugsnagTelemetrySDKName,
+			Key:   bugsnagSDKNameAttribute,
 			Value: attribute.StringValue(sdkName),
 		},
 		{
-			Key:   bugsnagTelemetrySDKVer,
+			Key:   bugsnagSDKVersionAttribute,
 			Value: attribute.StringValue(Version),
 		},
 	}

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -89,7 +89,16 @@ func createBugsnagMergedResource() *resource.Resource {
 		{
 			Key:   "service.version",
 			Value: attribute.StringValue(Config.AppVersion),
-		}}
+		},
+		{
+			Key:   "bugsnag.telemetry.sdk.name",
+			Value: attribute.StringValue("Go Bugsnag Performance SDK"),
+		},
+		{
+			Key:   "bugsnag.telemetry.sdk.version",
+			Value: attribute.StringValue(Version),
+		},
+	}
 	bsgResource, err := resource.Merge(
 		customResource,
 		resource.NewSchemaless(attr...),

--- a/consts.go
+++ b/consts.go
@@ -3,15 +3,15 @@ package bugsnagperformance
 import "time"
 
 const (
-	samplingAttribute       = "bugsnag.sampling.p"
-	samplingResponseHeader  = "Bugsnag-Sampling-Probability"
-	samplingRequestHeader   = "Bugsnag-Span-Sampling"
-	fetcherRetryInterval    = 30 * time.Second
-	fetcherRefreshInterval  = 24 * time.Hour
-	fetcherRequestBody      = `{"resourceSpans": []}`
-	deploymentEnvAttribute  = "deployment.environment"
-	serviceVersionAttribute = "service.version"
-	bugsnagTelemetrySDKName = "bugsnag.telemetry.sdk.name"
-	bugsnagTelemetrySDKVer  = "bugsnag.telemetry.sdk.version"
-	sdkName                 = "Go Bugsnag Performance SDK"
+	samplingAttribute          = "bugsnag.sampling.p"
+	samplingResponseHeader     = "Bugsnag-Sampling-Probability"
+	samplingRequestHeader      = "Bugsnag-Span-Sampling"
+	fetcherRetryInterval       = 30 * time.Second
+	fetcherRefreshInterval     = 24 * time.Hour
+	fetcherRequestBody         = `{"resourceSpans": []}`
+	deploymentEnvAttribute     = "deployment.environment"
+	serviceVersionAttribute    = "service.version"
+	bugsnagSDKNameAttribute    = "bugsnag.telemetry.sdk.name"
+	bugsnagSDKVersionAttribute = "bugsnag.telemetry.sdk.version"
+	sdkName                    = "Go Bugsnag Performance SDK"
 )

--- a/consts.go
+++ b/consts.go
@@ -3,10 +3,15 @@ package bugsnagperformance
 import "time"
 
 const (
-	samplingAttribute      = "bugsnag.sampling.p"
-	samplingResponseHeader = "Bugsnag-Sampling-Probability"
-	samplingRequestHeader  = "Bugsnag-Span-Sampling"
-	fetcherRetryInterval   = 30 * time.Second
-	fetcherRefreshInterval = 24 * time.Hour
-	fetcherRequestBody     = `{"resourceSpans": []}`
+	samplingAttribute       = "bugsnag.sampling.p"
+	samplingResponseHeader  = "Bugsnag-Sampling-Probability"
+	samplingRequestHeader   = "Bugsnag-Span-Sampling"
+	fetcherRetryInterval    = 30 * time.Second
+	fetcherRefreshInterval  = 24 * time.Hour
+	fetcherRequestBody      = `{"resourceSpans": []}`
+	deploymentEnvAttribute  = "deployment.environment"
+	serviceVersionAttribute = "service.version"
+	bugsnagTelemetrySDKName = "bugsnag.telemetry.sdk.name"
+	bugsnagTelemetrySDKVer  = "bugsnag.telemetry.sdk.version"
+	sdkName                 = "Go Bugsnag Performance SDK"
 )

--- a/delivery.go
+++ b/delivery.go
@@ -72,7 +72,7 @@ func createDelivery() *delivery {
 	headers := map[string]string{
 		"Bugsnag-Api-Key": Config.APIKey,
 		"Content-Type":    "application/json",
-		"User-Agent":      fmt.Sprintf("Go Bugsnag Performance SDK v%v", Version),
+		"User-Agent":      fmt.Sprintf("%v v%v", sdkName, Version),
 	}
 
 	return &delivery{

--- a/delivery.go
+++ b/delivery.go
@@ -84,7 +84,7 @@ func createDelivery() *delivery {
 func (d *delivery) send(headers map[string]string, payload []byte) (*http.Response, error) {
 	newHeaders := map[string]string{}
 
-	// TODO - add this back when pipeline is prepared to handle it
+	// TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
 	//newHeaders["Bugsnag-Sent-At"] = time.Now().Format(time.RFC3339)
 
 	// merge constant headers with the headers passed in

--- a/delivery.go
+++ b/delivery.go
@@ -83,7 +83,10 @@ func createDelivery() *delivery {
 
 func (d *delivery) send(headers map[string]string, payload []byte) (*http.Response, error) {
 	newHeaders := map[string]string{}
-	newHeaders["Bugsnag-Sent-At"] = time.Now().Format(time.RFC3339)
+
+	// TODO - add this back when pipeline is prepared to handle it
+	//newHeaders["Bugsnag-Sent-At"] = time.Now().Format(time.RFC3339)
+
 	// merge constant headers with the headers passed in
 	for k, v := range headers {
 		newHeaders[k] = v

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -80,9 +80,10 @@ func TestHeadersPresentAtSend(t *testing.T) {
 		if r.Header.Get("key1") != "value1" {
 			t.Errorf("Expected header key1 to be value1, got %s", r.Header.Get("key1"))
 		}
-		if r.Header.Get("Bugsnag-Sent-At") == "" {
-			t.Errorf("Expected header Bugsnag-Sent-At to be present")
-		}
+		// TODO - add this back when pipeline is ready
+		//if r.Header.Get("Bugsnag-Sent-At") == "" {
+		//	t.Errorf("Expected header Bugsnag-Sent-At to be present")
+		//}
 		if r.Header.Get("Bugsnag-Api-Key") != testAPIKey {
 			t.Errorf("Expected header Bugsnag-Api-Key to be %s, got %s", testAPIKey, r.Header.Get("Bugsnag-Api-Key"))
 		}

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -80,7 +80,7 @@ func TestHeadersPresentAtSend(t *testing.T) {
 		if r.Header.Get("key1") != "value1" {
 			t.Errorf("Expected header key1 to be value1, got %s", r.Header.Get("key1"))
 		}
-		// TODO - add this back when pipeline is ready
+		// TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
 		//if r.Header.Get("Bugsnag-Sent-At") == "" {
 		//	t.Errorf("Expected header Bugsnag-Sent-At to be present")
 		//}

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -89,7 +89,7 @@ func TestHeadersPresentAtSend(t *testing.T) {
 		if r.Header.Get("Content-Type") != "application/json" {
 			t.Errorf("Expected header Content-Type to be application/json, got %s", r.Header.Get("Content-Type"))
 		}
-		if r.Header.Get("User-Agent") != fmt.Sprintf("Go Bugsnag Performance SDK v%v", Version) {
+		if r.Header.Get("User-Agent") != fmt.Sprintf("%v v%v", sdkName, Version) {
 			t.Errorf("Expected header User-Agent to match current version, got %s", r.Header.Get("User-Agent"))
 		}
 	}))

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,8 @@
 Before do
   # we don't need to send the integrity header
   Maze.config.enforce_bugsnag_integrity = false
+  # TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
+  Maze.config.skip_default_validation('trace')
   $address = nil
   steps %(
     When I configure the maze endpoint


### PR DESCRIPTION
Adding attributes to track usage of our SDK - they are separated from `telemetry.sdk.name` and `.version` as we are not the main SDK, so using the `bugsnag.` prefix.

Also, due to a backend limitation we are removing the `Bugsnag-Sent-At` header temporarily to force spans to be routed as normal OTel spans, rather than BugSnag RUM. This will be restored once the backend is using `User-Agent` headers to control this.