### PR TITLE
v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,13 @@
 Changelog
 =========
+
+## 0.2.0 (2024-11-12)
+
+### Enhancements
+
+* Temporarily disable `Bugsnag-Sent-At` header. Add attributes with SDK name.
+[#20](https://github.com/bugsnag/bugsnag-go-performance/pull/20)
+
+## 0.1.0 (2024-11-06)
+
+### Initial release

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag performance module
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // Config is the configuration for the default Bugsnag performance module
 var Config Configuration


### PR DESCRIPTION
## 0.2.0 (2024-11-12)

### Enhancements

* Temporarily disable `Bugsnag-Sent-At` header. Add attributes with SDK name.
[#20](https://github.com/bugsnag/bugsnag-go-performance/pull/20)