### PR TITLE
Revert commenting out Bugsnag-Sent-At header

### DIFF
--- a/delivery.go
+++ b/delivery.go
@@ -84,9 +84,7 @@ func createDelivery() *delivery {
 
 func (d *delivery) send(headers map[string]string, payload []byte) (*http.Response, error) {
 	newHeaders := map[string]string{}
-
-	// TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
-	//newHeaders["Bugsnag-Sent-At"] = time.Now().Format(time.RFC3339)
+	newHeaders["Bugsnag-Sent-At"] = time.Now().Format(time.RFC3339)
 
 	// merge constant headers with the headers passed in
 	for k, v := range headers {

--- a/delivery_test.go
+++ b/delivery_test.go
@@ -80,10 +80,9 @@ func TestHeadersPresentAtSend(t *testing.T) {
 		if r.Header.Get("key1") != "value1" {
 			t.Errorf("Expected header key1 to be value1, got %s", r.Header.Get("key1"))
 		}
-		// TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
-		//if r.Header.Get("Bugsnag-Sent-At") == "" {
-		//	t.Errorf("Expected header Bugsnag-Sent-At to be present")
-		//}
+		if r.Header.Get("Bugsnag-Sent-At") == "" {
+			t.Errorf("Expected header Bugsnag-Sent-At to be present")
+		}
 		if r.Header.Get("Bugsnag-Api-Key") != testAPIKey {
 			t.Errorf("Expected header Bugsnag-Api-Key to be %s, got %s", testAPIKey, r.Header.Get("Bugsnag-Api-Key"))
 		}

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,8 +1,6 @@
 Before do
   # we don't need to send the integrity header
   Maze.config.enforce_bugsnag_integrity = false
-  # TODO - can be restored after https://smartbear.atlassian.net/browse/PIPE-7498
-  Maze.config.skip_default_validation('trace')
   $address = nil
   steps %(
     When I configure the maze endpoint


### PR DESCRIPTION
Related Pipeline ticket was finished, so `Bugsnag-Sent-At` header is restored.