### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+## 1.0.0 (2024-12-09)
+
+### Enhancements
+
+* Consolidate Go/Go-Perf environment variables.
+[#22](https://github.com/bugsnag/bugsnag-go-performance/pull/22)
+
+* Add Transport option in configuration.
+[#23](https://github.com/bugsnag/bugsnag-go-performance/pull/23)
+
+* Revert commenting out Bugsnag-Sent-At header.
+[#24](https://github.com/bugsnag/bugsnag-go-performance/pull/24)
+
+
 ## 0.2.0 (2024-11-12)
 
 ### Enhancements

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag performance module
-const Version = "0.2.0"
+const Version = "1.0.0"
 
 // Config is the configuration for the default Bugsnag performance module
 var Config Configuration


### PR DESCRIPTION
## 1.0.0 (2024-12-09)

### Enhancements

* Consolidate Go/Go-Perf environment variables.
[#22](https://github.com/bugsnag/bugsnag-go-performance/pull/22)

* Add Transport option in configuration.
[#23](https://github.com/bugsnag/bugsnag-go-performance/pull/23)

* Revert commenting out Bugsnag-Sent-At header.
[#24](https://github.com/bugsnag/bugsnag-go-performance/pull/24)