### PR TITLE
v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## TBD
+## 1.1.0 (2025-07-10)
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Set default endpoints based on API key [#29](https://github.com/bugsnag/bugsnag-go-performance/pull/29)
+
 ## 1.0.0 (2024-12-09)
 
 ### Enhancements

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag performance module
-const Version = "1.0.0"
+const Version = "1.1.0"
 
 // Config is the configuration for the default Bugsnag performance module
 var Config Configuration

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -37,7 +37,7 @@ func init() {
 func Configure(config Configuration) ([]trace.TracerProviderOption, error) {
 	readEnvConfigOnce.Do(Config.loadEnv)
 	Config.update(&config)
-	err := Config.validate()
+	err := Config.validate(&config)
 	if err != nil {
 		return nil, err
 	}

--- a/configuration.go
+++ b/configuration.go
@@ -12,6 +12,12 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
+const (
+	DEFAULT_ENDPOINT = "https://%+v.otlp.bugsnag.com/v1/traces"
+	HUB_ENDPOINT     = "https://%+v.otlp.insighthub.smartbear.com/v1/traces"
+	HUB_PREFIX       = "00000"
+)
+
 type Configuration struct {
 	// Your Bugsnag API key, e.g. "c9d60ae4c7e70c4b6c4ebd3e8056d2b8". You can
 	// find this by clicking Settings on https://bugsnag.com/.
@@ -115,14 +121,19 @@ func (config *Configuration) isReleaseStageEnabled() bool {
 	return false
 }
 
-func (config *Configuration) validate() error {
+func (config *Configuration) validate(other *Configuration) error {
 	if config.APIKey == "" {
 		return fmt.Errorf("no Bugsnag API Key set")
 	}
 
-	if config.Endpoint == "" {
-		defaultEndpoint := fmt.Sprintf("https://%+v.otlp.bugsnag.com/v1/traces", config.APIKey)
-		config.Endpoint = defaultEndpoint
+	if config.Endpoint == "" || other.Endpoint == "" {
+		defaultEndpoint := fmt.Sprintf(DEFAULT_ENDPOINT, config.APIKey)
+		hubEndpoint := fmt.Sprintf(HUB_ENDPOINT, config.APIKey)
+		if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
+			config.Endpoint = hubEndpoint
+		} else {
+			config.Endpoint = defaultEndpoint
+		}
 	}
 
 	return nil

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -71,10 +71,92 @@ func TestDefaultValues(t *testing.T) {
 	}
 }
 
+func TestDefaultHubValues(t *testing.T) {
+	resetEnv()
+	testConfig := Configuration{
+		APIKey:               "00000ffffeeee11112222333344445555",
+		Endpoint:             "https://00000ffffeeee11112222333344445555.otlp.insighthub.smartbear.com/v1/traces",
+		AppVersion:           "",
+		ReleaseStage:         "production",
+		EnabledReleaseStages: []string{},
+		Logger:               nil}
+
+	_, err := Configure(Configuration{
+		APIKey: "00000ffffeeee11112222333344445555",
+	})
+	if err != nil {
+		t.Error("should not return error")
+	}
+	if !configsEqual(&Config, &testConfig) {
+		t.Errorf("Config is: %+v, testConfig is: %+v\n", Config, testConfig)
+	}
+}
+
+func TestSecondConfigShouldSetHubEndpoint(t *testing.T) {
+	resetEnv()
+	testConfig := Configuration{
+		APIKey:               "aaa",
+		Endpoint:             "https://aaa.otlp.bugsnag.com/v1/traces",
+		AppVersion:           "",
+		ReleaseStage:         "production",
+		EnabledReleaseStages: []string{},
+		Logger:               nil}
+
+	testHubConfig := Configuration{
+		APIKey:               "00000ffffeeee11112222333344445555",
+		Endpoint:             "https://00000ffffeeee11112222333344445555.otlp.insighthub.smartbear.com/v1/traces",
+		AppVersion:           "",
+		ReleaseStage:         "production",
+		EnabledReleaseStages: []string{},
+		Logger:               nil}
+
+	// First configure with default values
+	_, err := Configure(Configuration{
+		APIKey: "aaa",
+	})
+	if err != nil {
+		t.Error("should not return error")
+	}
+	if !configsEqual(&Config, &testConfig) {
+		t.Errorf("Config is: %+v, testConfig is: %+v\n", Config, testConfig)
+	}
+
+	// Then configure with hub values
+	// This should overwrite the endpoint and API key
+	_, err = Configure(Configuration{
+		APIKey: "00000ffffeeee11112222333344445555",
+	})
+	if err != nil {
+		t.Error("should not return error")
+	}
+	if !configsEqual(&Config, &testHubConfig) {
+		t.Errorf("Config is: %+v, testHubConfig is: %+v\n", Config, testHubConfig)
+	}
+}
+
 func TestConfigureOverwriteDefault(t *testing.T) {
 	resetEnv()
 	testConfig := Configuration{
 		APIKey:               "bbb",
+		Endpoint:             "myendpoint",
+		AppVersion:           "123",
+		ReleaseStage:         "dev",
+		EnabledReleaseStages: []string{"dev"},
+		Logger:               nil}
+
+	_, err := Configure(testConfig)
+	if err != nil {
+		t.Error("should not return error")
+	}
+	if !configsEqual(&Config, &testConfig) {
+		t.Error()
+	}
+}
+
+func TestConfigureHubOverwriteDefault(t *testing.T) {
+	resetEnv()
+	testConfig := Configuration{
+		APIKey:               "00000ffffeeee11112222333344445555",
 		Endpoint:             "myendpoint",
 		AppVersion:           "123",
 		ReleaseStage:         "dev",


### PR DESCRIPTION
## 1.1.0 (2025-07-10)

### Enhancements

* Set default endpoints based on API key [#29](https://github.com/bugsnag/bugsnag-go-performance/pull/29)