### PR TITLE
Handle endpoint being set only in env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## TBD
+
+### Bug fixes
+
+* Handle endpoint being set only in env var [#32](https://github.com/bugsnag/bugsnag-go-performance/pull/32)
+
 ## 1.1.0 (2025-07-10)
 
 ### Enhancements

--- a/bugsnag_performance_test.go
+++ b/bugsnag_performance_test.go
@@ -12,5 +12,6 @@ func resetEnv() {
 		ReleaseStage: "production",
 		Logger:       log.New(os.Stdout, "[BugsnagPerformance] ", log.LstdFlags),
 		MainContext:  context.TODO(),
+		Endpoint:     "",
 	}
 }

--- a/configuration.go
+++ b/configuration.go
@@ -126,7 +126,7 @@ func (config *Configuration) validate(other *Configuration) error {
 		return fmt.Errorf("no Bugsnag API Key set")
 	}
 
-	if config.Endpoint == "" || other.Endpoint == "" {
+	if config.Endpoint == "" && other.Endpoint == "" {
 		defaultEndpoint := fmt.Sprintf(DEFAULT_ENDPOINT, config.APIKey)
 		hubEndpoint := fmt.Sprintf(HUB_ENDPOINT, config.APIKey)
 		if strings.HasPrefix(config.APIKey, HUB_PREFIX) {


### PR DESCRIPTION
## Goal
If user provided Endpoint configuration only by Environment variable in the current solution they would still be overwritten by defaults.

## Changeset
If the endpoint value is already set and the next config does not specify it - then do not update the value with default.

## Testing
Added unit tests that set environment variables.
Removed unit test to check if the default endpoint will be overwritten by new default when API key changes - that scenario should not be supported.