### PR TITLE
Update version to 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## 1.1.2 (2026-01-22)
+
+### Enhancements
+
+* Amend default secondary instance URL name [#35](https://github.com/bugsnag/bugsnag-go-performance/pull/35)
+
 ## 1.1.1 (2025-07-29)
 
 ### Bug fixes

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag performance module
-const Version = "1.1.1"
+const Version = "1.1.2"
 
 // Config is the configuration for the default Bugsnag performance module
 var Config Configuration


### PR DESCRIPTION
## 1.1.2 (2026-01-22)

### Enhancements

* Amend default secondary instance URL name [#35](https://github.com/bugsnag/bugsnag-go-performance/pull/35)