### PR TITLE
v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+## 1.1.2 (2026-01-22)
+
+### Enhancements
+
+* Amend default secondary instance URL name [#35](https://github.com/bugsnag/bugsnag-go-performance/pull/35)
+
 ## 1.1.1 (2025-07-29)
 
 ### Bug fixes

--- a/bugsnag_performance.go
+++ b/bugsnag_performance.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version defines the version of this Bugsnag performance module
-const Version = "1.1.1"
+const Version = "1.1.2"
 
 // Config is the configuration for the default Bugsnag performance module
 var Config Configuration

--- a/configuration.go
+++ b/configuration.go
@@ -13,9 +13,9 @@ import (
 )
 
 const (
-	DEFAULT_ENDPOINT = "https://%+v.otlp.bugsnag.com/v1/traces"
-	HUB_ENDPOINT     = "https://%+v.otlp.insighthub.smartbear.com/v1/traces"
-	HUB_PREFIX       = "00000"
+	DEFAULT_ENDPOINT          = "https://%+v.otlp.bugsnag.com/v1/traces"
+	SECONDARY_ENDPOINT        = "https://%+v.otlp.bugsnag.smartbear.com/v1/traces"
+	SECONDARY_ENDPOINT_PREFIX = "00000"
 )
 
 type Configuration struct {
@@ -128,9 +128,9 @@ func (config *Configuration) validate(other *Configuration) error {
 
 	if config.Endpoint == "" && other.Endpoint == "" {
 		defaultEndpoint := fmt.Sprintf(DEFAULT_ENDPOINT, config.APIKey)
-		hubEndpoint := fmt.Sprintf(HUB_ENDPOINT, config.APIKey)
-		if strings.HasPrefix(config.APIKey, HUB_PREFIX) {
-			config.Endpoint = hubEndpoint
+		secondaryEndpoint := fmt.Sprintf(SECONDARY_ENDPOINT, config.APIKey)
+		if strings.HasPrefix(config.APIKey, SECONDARY_ENDPOINT_PREFIX) {
+			config.Endpoint = secondaryEndpoint
 		} else {
 			config.Endpoint = defaultEndpoint
 		}

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -71,11 +71,11 @@ func TestDefaultValues(t *testing.T) {
 	}
 }
 
-func TestDefaultHubValues(t *testing.T) {
+func TestDefaultSecondaryEndpointValues(t *testing.T) {
 	resetEnv()
 	testConfig := Configuration{
 		APIKey:               "00000ffffeeee11112222333344445555",
-		Endpoint:             "https://00000ffffeeee11112222333344445555.otlp.insighthub.smartbear.com/v1/traces",
+		Endpoint:             "https://00000ffffeeee11112222333344445555.otlp.bugsnag.smartbear.com/v1/traces",
 		AppVersion:           "",
 		ReleaseStage:         "production",
 		EnabledReleaseStages: []string{},
@@ -111,7 +111,7 @@ func TestConfigureOverwriteDefault(t *testing.T) {
 	}
 }
 
-func TestConfigureHubOverwriteDefault(t *testing.T) {
+func TestConfigureSecondaryEndpointOverwriteDefault(t *testing.T) {
 	resetEnv()
 	testConfig := Configuration{
 		APIKey:               "00000ffffeeee11112222333344445555",
@@ -219,10 +219,10 @@ func TestConfigureNotifierEnv(t *testing.T) {
 
 func TestEndpointFromEnvironment(t *testing.T) {
 	customEndpoint := "https://endpoint.custom.com"
-	hubAPIKey := "00000abcdef0123456789abcdef012345"
+	secondaryAPIKey := "00000abcdef0123456789abcdef012345"
 	setUp := func() {
 		os.Setenv("BUGSNAG_PERFORMANCE_ENDPOINT", customEndpoint)
-		os.Setenv("BUGSNAG_API_KEY", hubAPIKey)
+		os.Setenv("BUGSNAG_API_KEY", secondaryAPIKey)
 	}
 
 	t.Run("Should not override endpoint set by environment variable", func(st *testing.T) {
@@ -231,7 +231,7 @@ func TestEndpointFromEnvironment(t *testing.T) {
 
 		testConfig := Configuration{
 			Endpoint:     customEndpoint,
-			APIKey:       hubAPIKey,
+			APIKey:       secondaryAPIKey,
 			ReleaseStage: "production",
 		}
 
@@ -255,7 +255,7 @@ func TestEndpointFromEnvironment(t *testing.T) {
 		newCustomEndpoint := "https://test.endpoint.com"
 		testConfig := Configuration{
 			Endpoint:     newCustomEndpoint,
-			APIKey:       hubAPIKey,
+			APIKey:       secondaryAPIKey,
 			ReleaseStage: "production",
 		}
 


### PR DESCRIPTION
## 1.1.2 (2026-01-22)

### Enhancements

* Amend default secondary instance URL name [#35](https://github.com/bugsnag/bugsnag-go-performance/pull/35)